### PR TITLE
chore: update CODEOWNERS for dependency files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,7 @@
 * @kinde-starter-kits/giants-kinde
 
+pom.xml @kinde-starter-kits/sdk-engineers
+**/pom.xml @kinde-starter-kits/sdk-engineers
+.mvn/wrapper/** @kinde-starter-kits/sdk-engineers
+mvnw @kinde-starter-kits/sdk-engineers
+mvnw.cmd @kinde-starter-kits/sdk-engineers


### PR DESCRIPTION
Automated update to CODEOWNERS so that @kinde-oss/sdk-engineers own dependency definition files and can approve dependency PRs.